### PR TITLE
修复添加Referer的Header时出现的bug

### DIFF
--- a/lib/option.py
+++ b/lib/option.py
@@ -69,7 +69,7 @@ class Option:
         self.headers = {}
         if option.headers:
             for h in option.headers:
-                hn, hv = h.split(': ')
+                hn, hv = h.split(':', 1)
                 self.headers[hn.strip()] = hv.strip()
 
         self.redirect = option.redirect

--- a/lib/option.py
+++ b/lib/option.py
@@ -69,7 +69,7 @@ class Option:
         self.headers = {}
         if option.headers:
             for h in option.headers:
-                hn, hv = h.split(':')
+                hn, hv = h.split(': ')
                 self.headers[hn.strip()] = hv.strip()
 
         self.redirect = option.redirect


### PR DESCRIPTION
airsearch-master/lib/option.py 72行

hv = h.split(':')  →  hv = h.split(': ')

应对如下情况
python3 airsearch.py -H "Referer: http://abc.com/hello?bye=123"   http://abc.com